### PR TITLE
Fix roleinfo.js (hopefully)

### DIFF
--- a/src/Commands/Information/roleinfo.js
+++ b/src/Commands/Information/roleinfo.js
@@ -18,8 +18,9 @@ module.exports = {
             },
       },
       Run: async (client, message, paramaters) => {
-            if (!paramaters[0]) return message.channel.send(errors.MissingArgs)
-            const role = message.guild.roles.find(f => f.name.toLowerCase() === paramaters[0].toLowerCase()) || message.mentions.roles.first()
+            const paramatersv2 = message.content.split(' ').splice(1).join(' '); // You can name this whatever you want, or alternatively just use parameters without [0]
+            if (!paramatersv2) return message.channel.send(errors.MissingArgs)
+            const role = message.guild.roles.find(f => f.name.toLowerCase() === paramatersv2.toLowerCase()) || message.mentions.roles.first()
             const specials = []
             if(role.serialize().ADMINISTRATOR) {
                   specials.push('Administrator')


### PR DESCRIPTION
Fix roleinfo.js not doing anything when you do x!roleinfo [role name with spaces]

Examples:
"x!roleinfo blue" works fine, sends embed with all the info
"x!roleinfo staff team" doesn't send message and doesn't throw any error messages in chat

I believe this was caused because you were getting the role's name by using parameters[0] instead of just parameters, hopefully this fixes the issue